### PR TITLE
fixed UTF conversion

### DIFF
--- a/Leo Dictionary/source/utils.php
+++ b/Leo Dictionary/source/utils.php
@@ -1,7 +1,7 @@
 <?php
 
 function clean_utf8($string) {
-	return iconv('UTF-8-Mac', 'UTF-8', $string);
+	return iconv('UTF-8', 'UTF-8', $string);
 }
 
 ?>


### PR DESCRIPTION
Since some time, the Leo workflow was not working for me. I performed a Wireshark trace and saw that the GET request had an empty "`search=`" parameter. Digging further into the code, I noticed that the problem seems to lie in the `iconv` method in. Apparently, the "`UTF-8-Mac`" encoding is not available on my system:
Mac OS X 10.10.3
PHP 5.6.7

Changing it to "`UTF-8`" immediately resolved the problem for me.